### PR TITLE
Fixes entry listing on profile page

### DIFF
--- a/app/Http/Controllers/EntriesController.php
+++ b/app/Http/Controllers/EntriesController.php
@@ -380,7 +380,7 @@ class EntriesController extends Controller
   public function getEntriesDataView(Request $request, $user_id=null)
   {
     if ($user_id) {
-      $entries = $request->whitelabel_group->entries()->with('author')->where('created_by', $user_id)->get();
+      $entries = $request->whitelabel_group->entries()->with('author')->where('created_by', $user_id);
     }
     else {
       $entries = $request->whitelabel_group->entries()->with('author')->NotCompleted();


### PR DESCRIPTION
Have the get(), even though it returned the same entry count was causing the "Method orderBy does not exist" error. So I presume get() returns a different type of object. Maybe when you have time Alison you can explain this to me.
