### PR TITLE
#171 migration to add verified & token to users

### DIFF
--- a/database/migrations/2016_05_04_202452_add_email_verification_flag.php
+++ b/database/migrations/2016_05_04_202452_add_email_verification_flag.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEmailVerificationFlag extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function(Blueprint $table)
+        {
+            $table->boolean('verified')->default(false);
+            $table->string('token')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function(Blueprint $table)
+        {
+            $table->dropColumn('verified');
+            $table->dropColumn('token');
+        });
+    }
+}


### PR DESCRIPTION
add a boolean 'verified' and a string 'token' to the users table. Rollback has been tested. This is all for email verification on signing up. Let me know if I'm barking up the wrong tree.
