### PR TITLE
Fixes #369 hide join share link if user has asked

### DIFF
--- a/resources/themes/whitelabel/partials/header.blade.php
+++ b/resources/themes/whitelabel/partials/header.blade.php
@@ -123,7 +123,7 @@
         <div class="margin-left-10 navbar-collapse pull-right nav-main-collapse collapse">
           <nav class="nav-main">
             <ul id="topMain" class="nav nav-pills nav-main nav-onepage">
-            @if ((Auth::check()) && (!Auth::user()->isMemberOfCommunity($whitelabel_group)))
+            @if ((Auth::check()) && (!Auth::user()->isMemberOfCommunity($whitelabel_group)) && !$whitelabel_group->getRequestCount(Auth::user()->id))
               <li>
                 <a style="color:white;" href="{{ route('community.request-access.form') }}">
                   <button type="button" class="btn btn-warning btn-sm">


### PR DESCRIPTION
I’m referring the the orange join share button in the whitelabel nav bar.If they have a join request already pending, no point in showing it to them as it won’t do anything for the user